### PR TITLE
Replaced Twitter bird logo with X logo in exhibition.html

### DIFF
--- a/exhibition.html
+++ b/exhibition.html
@@ -636,7 +636,8 @@
         </p>
         <div class="flex gap-4 mt-6">
           <a href="#" class="p-2 bg-white rounded-full shadow-lg hover:scale-110 hover:bg-gradient-to-r hover:from-[#6C63FF] hover:to-[#ff6bcb] transition-all duration-300"><i class="fab fa-facebook-f text-[#6C63FF] hover:text-white"></i></a>
-          <a href="#" class="p-2 bg-white rounded-full shadow-lg hover:scale-110 hover:bg-gradient-to-r hover:from-[#6C63FF] hover:to-[#ff6bcb] transition-all duration-300"><i class="fab fa-twitter text-[#6C63FF] hover:text-white"></i></a>
+          <!-- issue #63 -->
+          <a href="#" class="p-2 bg-white rounded-full shadow-lg hover:scale-110 hover:bg-gradient-to-r hover:from-[#6C63FF] hover:to-[#ff6bcb] transition-all duration-300"><i class="fa-brands fa-x-twitter text-[#6C63FF] hover:text-white"></i></a>
           <a href="#" class="p-2 bg-white rounded-full shadow-lg hover:scale-110 hover:bg-gradient-to-r hover:from-[#6C63FF] hover:to-[#ff6bcb] transition-all duration-300"><i class="fab fa-instagram text-[#6C63FF] hover:text-white"></i></a>
           <a href="#" class="p-2 bg-white rounded-full shadow-lg hover:scale-110 hover:bg-gradient-to-r hover:from-[#6C63FF] hover:to-[#ff6bcb] transition-all duration-300"><i class="fab fa-linkedin-in text-[#6C63FF] hover:text-white"></i></a>
         </div>
@@ -687,7 +688,8 @@
 
         <div class="flex gap-4 mt-6 justify-center sm:justify-start">
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-facebook-f"></i></a>
-          <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-twitter"></i></a>
+          <!-- issue #63 -->
+          <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fa-brands fa-x-twitter"></i></a>
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-instagram"></i></a>
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-linkedin-in"></i></a>
         </div>


### PR DESCRIPTION
## 🚀 Pull Request

### 🔖 Description
Replaced the old Twitter bird logo with the new X logo on `exhibition.html`.  
Ensures consistent branding across the site.

Fixes: #63 

---

### 📸 Screenshots (if applicable)

Before:-

<img width="3420" height="1598" alt="Screenshot 2025-09-08 at 9 17 24 PM" src="https://github.com/user-attachments/assets/d559e0c3-26af-440c-9109-09040442bc3e" />


After:-

<img width="3420" height="1678" alt="Screenshot 2025-09-08 at 9 46 20 PM" src="https://github.com/user-attachments/assets/42a5f6f1-4576-4f5e-84e7-3b3085e6006c" />


---
