### PR TITLE
Fix Explore footer: Move newsletter social icons inside box and remove duplicates

### DIFF
--- a/exhibition.html
+++ b/exhibition.html
@@ -715,12 +715,9 @@ document.addEventListener("DOMContentLoaded", function() {
       Subscribe
     </button>
   </form>
-</div>
-
-        <div class="flex gap-4 mt-6 justify-center sm:justify-start">
+   <div class="flex gap-4 mt-6 justify-center sm:justify-start">
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-facebook-f"></i></a>
-          <!-- issue #63 -->
-          <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fa-brands fa-x-twitter"></i></a>
+          <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-x-twitter"></i></a>
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-instagram"></i></a>
           <a href="#" class="text-[#6C63FF] hover:text-[#ff6bcb] transition-all duration-300 text-2xl hover:scale-110"><i class="fab fa-linkedin-in"></i></a>
         </div>


### PR DESCRIPTION
This PR addresses issue #98 

## PR Description:

## Issue:
On the Explore page footer, the social icons meant for the newsletter section were showing below the site description’s icons, creating duplication and messy layout.

## Changes Made:

- Moved the newsletter social icons inside the newsletter container, matching the home page layout.

- Removed duplicate social icons under the site description section.

- Ensured the newsletter section remains responsive and neatly aligned on all screen sizes.

## Visual Reference 
### Before
<img width="1884" height="462" alt="image" src="https://github.com/user-attachments/assets/79685eb3-1e06-4cd8-b3d1-1e657e3ce342" />

---

### After 
<img width="1907" height="591" alt="image" src="https://github.com/user-attachments/assets/c74da548-53e0-495e-8b12-e718a24b0210" />
