### PR TITLE
fix(nav): highlight active nav link based on current page

### DIFF
--- a/Artist Portal.html
+++ b/Artist Portal.html
@@ -267,6 +267,20 @@
     }
   });
 })();</script>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const currentPage = window.location.pathname.split("/").pop(); // e.g., "about.html"
+    const navLinks = document.querySelectorAll(".nav-link");
+
+    navLinks.forEach(link => {
+      if (link.getAttribute("href") === currentPage) {
+        link.classList.add("active");
+      }
+    });
+  });
+</script>
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.1/jquery.min.js" integrity="sha512-aVKKRRi/Q/YV+4mjoKBsE4x3H+BkegoM/em46NNlCqNTmUYADjBbeNefNxYV7giUp0VxICtqdrbqU7iVaeZNXA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="assets/js/blog.js"></script>
 </body>

--- a/about.html
+++ b/about.html
@@ -756,6 +756,20 @@
 });
 </script>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const currentPage = window.location.pathname.split("/").pop(); // e.g., "about.html"
+    const navLinks = document.querySelectorAll(".nav-link");
+
+    navLinks.forEach(link => {
+      if (link.getAttribute("href") === currentPage) {
+        link.classList.add("active");
+      }
+    });
+  });
+</script>
+
+
 
 <!-- Theme Toggle Script -->
 <script src="theme-toggle.js"></script>

--- a/artwork.html
+++ b/artwork.html
@@ -1475,5 +1475,18 @@
 })();
 </script>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const currentPage = window.location.pathname.split("/").pop(); // e.g., "about.html"
+    const navLinks = document.querySelectorAll(".nav-link");
+
+    navLinks.forEach(link => {
+      if (link.getAttribute("href") === currentPage) {
+        link.classList.add("active");
+      }
+    });
+  });
+</script>
+
 </body>
 </html>

--- a/exhibition.html
+++ b/exhibition.html
@@ -1313,5 +1313,18 @@
 })();
 </script>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const currentPage = window.location.pathname.split("/").pop(); // e.g., "about.html"
+    const navLinks = document.querySelectorAll(".nav-link");
+
+    navLinks.forEach(link => {
+      if (link.getAttribute("href") === currentPage) {
+        link.classList.add("active");
+      }
+    });
+  });
+</script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1595,5 +1595,19 @@ bg-gradient-to-b from-purple-200 via-pink-100 to-white overflow-hidden">
       }
     })();
     </script>
+
+    <script>
+  document.addEventListener("DOMContentLoaded", function () {
+    const currentPage = window.location.pathname.split("/").pop(); // e.g., "about.html"
+    const navLinks = document.querySelectorAll(".nav-link");
+
+    navLinks.forEach(link => {
+      if (link.getAttribute("href") === currentPage) {
+        link.classList.add("active");
+      }
+    });
+  });
+</script>
+
   </body>
 </html>


### PR DESCRIPTION
@gaincyst 
This PR fixes the issue (#137)  where the active page in the navbar wasn’t highlighted FOR ALL PAGES IN BOTH LIGHT AND DARK MODE.

### Kindly add GSSoC'25, LEVEL and other labels for this PR before mering it.

### Changes Made:

- Added a script to detect the current page from window.location.pathname.
- Applied the active class to the matching nav link automatically.

### Why:
Ensures users can easily see which page they are on, improving navigation clarity and overall UX.

### Screenshots:

**Before-**
<img width="1919" height="524" alt="image" src="https://github.com/user-attachments/assets/b48b29cd-8ff3-4a35-8af5-a36b57253cb4" />


**After-**
<img width="1919" height="250" alt="image" src="https://github.com/user-attachments/assets/17208e8a-7410-4112-aee4-68fa04cf94cd" />
<img width="1919" height="351" alt="image" src="https://github.com/user-attachments/assets/d68867a5-63c4-4c92-8d2e-1a022633f1e7" />
