### PR TITLE
Add -webkit-backdrop-filter for Safari compatibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -100,6 +100,7 @@
       height: 3rem;
       background-color: rgba(255, 255, 255, 0.2);
       backdrop-filter: blur(16px);
+      -webkit-backdrop-filter: blur(16px);
       border-radius: 50%;
       border: 1px solid rgba(255, 255, 255, 0.3);
       cursor: pointer;
@@ -139,6 +140,7 @@
     .dark header {
       background: linear-gradient(to right, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.8)) !important;
       backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
     }
 
     /* Text color adjustments for dark mode */
@@ -156,6 +158,7 @@
     .dark #mobile-menu {
       background: rgba(15, 23, 42, 0.98) !important;
       backdrop-filter: blur(20px);
+      -webkit-backdrop-filter: blur(20px);
     }
 
     .dark .border-gray-200 {

--- a/artwork.html
+++ b/artwork.html
@@ -196,6 +196,7 @@
   height: 3rem !important;
   background-color: rgba(255, 255, 255, 0.9) !important;
   backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px);
   border-radius: 50% !important;
   border: 1px solid rgba(255, 255, 255, 0.3) !important;
   cursor: pointer !important;
@@ -238,6 +239,7 @@
 [data-theme="dark"] header {
   background: linear-gradient(to right, rgba(26, 32, 44, 0.95), rgba(45, 55, 72, 0.9)) !important;
   backdrop-filter: blur(20px) !important;
+  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(156, 163, 175, 0.2) !important;
 }
 

--- a/exhibition.html
+++ b/exhibition.html
@@ -99,6 +99,7 @@
     .glass {
       background: rgba(255,255,255,0.6);
       backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
     }
 
     /* small helper for clamping description */
@@ -189,6 +190,7 @@
   height: 3rem !important;
   background-color: rgba(255, 255, 255, 0.9) !important;
   backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px);
   border-radius: 50% !important;
   border: 1px solid rgba(255, 255, 255, 0.3) !important;
   cursor: pointer !important;
@@ -231,6 +233,7 @@
 [data-theme="dark"] header {
   background: linear-gradient(to right, rgba(26, 32, 44, 0.95), rgba(45, 55, 72, 0.9)) !important;
   backdrop-filter: blur(20px) !important;
+  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(156, 163, 175, 0.2) !important;
 }
 

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
   height: 3rem !important;
   background-color: rgba(255, 255, 255, 0.9) !important;
   backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px);
   border-radius: 50% !important;
   border: 1px solid rgba(255, 255, 255, 0.3) !important;
   cursor: pointer !important;
@@ -265,6 +266,7 @@
 [data-theme="dark"] header {
   background: linear-gradient(to right, rgba(26, 32, 44, 0.95), rgba(45, 55, 72, 0.9)) !important;
   backdrop-filter: blur(20px) !important;
+  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid rgba(156, 163, 175, 0.2) !important;
 }
 
@@ -298,6 +300,7 @@
 [data-theme="dark"] #mobile-menu {
   background: rgba(26, 32, 44, 0.98) !important;
   backdrop-filter: blur(20px) !important;
+  -webkit-backdrop-filter: blur(20px);
   border-top: 1px solid rgba(156, 163, 175, 0.2) !important;
 }
 
@@ -311,6 +314,7 @@
 [data-theme="dark"] .bg-gray-100 {
   background-color: rgba(45, 55, 72, 0.9) !important;
   backdrop-filter: blur(10px) !important;
+  -webkit-backdrop-filter: blur(10px);
   border: 1px solid rgba(75, 85, 99, 0.3) !important;
 }
 


### PR DESCRIPTION
**Summary**
This PR adds the `-webkit-backdrop-filter` property in addition to backdrop-filter.

**Issue**
Issue: #171 

**Reason**
Some browsers (especially Safari iOS/macOS) only support the prefixed `-webkit-backdrop-filter`. Removing one of them causes inconsistent rendering across browsers. Keeping both ensures proper fallback and broader compatibility.

**Changes**

Added `-webkit-backdrop-filter` alongside backdrop-filter

Updated affected CSS rules to include both properties

**Impact**
This change improves cross-browser compatibility without altering existing behavior on browsers that already support `backdrop-filter`.